### PR TITLE
fix: increase connection timeout to avoid cUrl errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ If you need more functionality you get an instance of the underlying Api with:
 $api = Newsletter::getApi();
 ```
 
+### Mailjet notes
+
+Connection timeouts may occur when using mailjet, as described
+[here](https://github.com/mailjet/mailjet-apiv3-php/issues/157). You can
+configure the value you want with configuration key
+`mailjet.connection_timeout`, itself using environment variable
+`MJ_CONNECTION_TIMEOUT`.
+
+
 ## Testing
 
 Run the tests with:

--- a/config/newsletter.php
+++ b/config/newsletter.php
@@ -47,7 +47,7 @@ return [
     'mailjet' => [
         'key' => env('MJ_APIKEY_PUBLIC'),
         'secret' => env('MJ_APIKEY_PRIVATE'),
-        'connection_timeout' => (float)env('MJ_CONNECTION_TIMEOUT', '20'),
+        'connection_timeout' => env('MJ_CONNECTION_TIMEOUT'),
     ]
 
 ];

--- a/config/newsletter.php
+++ b/config/newsletter.php
@@ -47,6 +47,7 @@ return [
     'mailjet' => [
         'key' => env('MJ_APIKEY_PUBLIC'),
         'secret' => env('MJ_APIKEY_PRIVATE'),
+        'connection_timeout' => (float)env('MJ_CONNECTION_TIMEOUT', '20'),
     ]
 
 ];

--- a/src/Drivers/MailjetDriver.php
+++ b/src/Drivers/MailjetDriver.php
@@ -21,7 +21,10 @@ class MailjetDriver implements Driver
     public function __construct(array $credentials, array $config)
     {
         $this->client = new Client($credentials['key'], $credentials['secret']);
-        $this->client->setConnectionTimeout(20);
+        $connectionTimeout = $config['connection_timeout'];
+        if ($connectionTimeout > 0) {
+            $this->client->setConnectionTimeout($connectionTimeout);
+        }
         $this->lists = NewsletterListCollection::createFromConfig($config);
     }
 

--- a/src/Drivers/MailjetDriver.php
+++ b/src/Drivers/MailjetDriver.php
@@ -22,7 +22,7 @@ class MailjetDriver implements Driver
     {
         $this->client = new Client($credentials['key'], $credentials['secret']);
         $connectionTimeout = $config['connection_timeout'];
-        if ($connectionTimeout > 0) {
+        if ($connectionTimeout) {
             $this->client->setConnectionTimeout($connectionTimeout);
         }
         $this->lists = NewsletterListCollection::createFromConfig($config);

--- a/src/Drivers/MailjetDriver.php
+++ b/src/Drivers/MailjetDriver.php
@@ -21,6 +21,7 @@ class MailjetDriver implements Driver
     public function __construct(array $credentials, array $config)
     {
         $this->client = new Client($credentials['key'], $credentials['secret']);
+        $this->client->setConnectionTimeout(20);
         $this->lists = NewsletterListCollection::createFromConfig($config);
     }
 

--- a/src/NewsletterServiceProvider.php
+++ b/src/NewsletterServiceProvider.php
@@ -38,6 +38,7 @@ class NewsletterServiceProvider extends ServiceProvider
                     $driver = new MailchimpDriver(config('newsletter.mailchimp'), $config);
                     break;
                 case 'mailjet':
+                    $config['connection_timeout'] = config('newsletter.mailjet.connection_timeout');
                     $driver = new MailjetDriver(config('newsletter.mailjet'), $config);
                     break;
             }

--- a/tests/Mailjet/NewsletterTest.php
+++ b/tests/Mailjet/NewsletterTest.php
@@ -40,6 +40,7 @@ class NewsletterTest extends TestCase
                 'list2' => ['id' => 456],
             ],
             'defaultList' => 'list1',
+            'connection_timeout' => 20,
         ]);
 
         $this->driver->client = $this->client;


### PR DESCRIPTION
Errors are thrown randomly (though several times a day) because of
connection timeout. Default timeout set by mailjet client is 2s. Mailjet
support advises
[here](https://github.com/mailjet/mailjet-apiv3-php/issues/157) to raise
the timeout to 20s max.

Another solution is to rerun the request. It could be done if errors
still occur.