### PR TITLE
Fix add member method

### DIFF
--- a/src/Drivers/MailjetDriver.php
+++ b/src/Drivers/MailjetDriver.php
@@ -177,7 +177,7 @@ class MailjetDriver implements Driver
         $contactLists = $response->getData();
 
         foreach ($contactLists as $list) {
-            if ($list['ListID'] === $listId && $list['IsUnsub'] !== true) {
+            if ((string)$list['ListID'] === $listId && $list['IsUnsub'] !== true) {
                 return true;
             }
         }

--- a/src/Drivers/MailjetDriver.php
+++ b/src/Drivers/MailjetDriver.php
@@ -82,7 +82,7 @@ class MailjetDriver implements Driver
             throw ApiError::responseError($response->getReasonPhrase(), 'mailjet', $response->getStatus());
         }
 
-        $this->unsubscribe($email, $listName);
+        return $this->unsubscribe($email, $listName);
     }
 
     /**

--- a/src/Drivers/MailjetDriver.php
+++ b/src/Drivers/MailjetDriver.php
@@ -38,7 +38,7 @@ class MailjetDriver implements Driver
 
         $body = [
             'Email' => $email,
-            'Action' => 'addnoforce',
+            'Action' => 'addforce',
         ];
 
         $body = array_merge($body, $options);

--- a/src/Drivers/MailjetDriver.php
+++ b/src/Drivers/MailjetDriver.php
@@ -75,9 +75,14 @@ class MailjetDriver implements Driver
      */
     public function addMember(string $email, array $options = [], string $listName = '')
     {
-        return $this->subscribe($email, array_merge([
-            'IsExcludedFromCampaigns' => true,
-        ], $options), $listName);
+        $response = $this->subscribe($email, $options, $listName);
+
+        if (!$response->success()) {
+            $this->lastError = $response->getData();
+            throw ApiError::responseError($response->getReasonPhrase(), 'mailjet', $response->getStatus());
+        }
+
+        $this->unsubscribe($email, $listName);
     }
 
     /**

--- a/tests/Mailjet/NewsletterTest.php
+++ b/tests/Mailjet/NewsletterTest.php
@@ -283,7 +283,7 @@ class NewsletterTest extends TestCase
         $response->shouldReceive('success')->andReturn(true);
         $response->shouldReceive('getData')->andReturn([
             [
-                'ListID' => '123',
+                'ListID' => 123,
                 'IsUnsub' => false
             ]
         ]);

--- a/tests/Mailjet/NewsletterTest.php
+++ b/tests/Mailjet/NewsletterTest.php
@@ -74,7 +74,7 @@ class NewsletterTest extends TestCase
                 'id' => '123',
                 'body' => [
                     'Email' => "test@test.fr",
-                    'Action' => "addnoforce",
+                    'Action' => "addforce",
                     'Name' => 'Martin',
                 ]
             ]
@@ -94,7 +94,7 @@ class NewsletterTest extends TestCase
                 'id' => '123',
                 'body' => [
                     'Email' => "test@test.fr",
-                    'Action' => "addnoforce",
+                    'Action' => "addforce",
                     'Name' => 'Martin',
                 ]
             ]
@@ -114,7 +114,7 @@ class NewsletterTest extends TestCase
                 'id' => '123',
                 'body' => [
                     'Email' => "testtest.fr",
-                    'Action' => "addnoforce",
+                    'Action' => "addforce",
                     'Name' => 'Martin',
                 ]
             ]
@@ -397,5 +397,35 @@ class NewsletterTest extends TestCase
 
         $this->expectExceptionObject(ApiError::responseError('Error', 'mailjet', 400));
         $this->newsletter->hasMember('test@test.fr');
+    }
+
+    /** @test */
+    public function it_can_add_member_to_a_list()
+    {
+        $this->response->shouldReceive('success')->andReturn(true);
+
+        $this->client->shouldReceive('post')->withArgs([
+            Resources::$ContactslistManagecontact,[
+                'id' => '123',
+                'body' => [
+                    'Email' => 'test@test.fr',
+                    'Action' => 'addforce',
+                ]
+            ]
+
+        ])->andReturn($this->response);
+
+        $this->client->shouldReceive('post')->withArgs([
+            Resources::$ContactslistManagecontact,[
+                'id' => '123',
+                'body' => [
+                    'Email' => 'test@test.fr',
+                    'Action' => 'unsub',
+                ]
+            ]
+
+        ])->andReturn($this->response);
+
+        $this->newsletter->addMember('test@test.fr');
     }
 }


### PR DESCRIPTION
The option `IsExcludedFromCampaigns` is not available on the resource `Resources::$ContactslistManagecontact` for Mailjet. The aim of `addMember` method is to add an email to a contact list without allowing marketing sending. The closest way to do so is to subscribe the email then unsubscribe it.

Using `IsExcludedFromCampaigns` with the proper resource add the email to Mailjet's _exclusion list_. When doing so, the method `isSubscribed` won't work.